### PR TITLE
Add semicolon to newline conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,5 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 - Initial release
+- Added command to convert semicolons to newlines
+

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 - 🔁 Convert double newlines (`\n\n`) into single (`\n`)
 - 🔁 Convert single newlines (`\n`) into double (`\n\n`)
+- 🔁 Replace semicolons (`;`) with newlines (`\n`)
 - 💡 Works on selected text or the entire document
 
 ---
@@ -17,6 +18,7 @@
 2. Search for one of the following:
    - `LineFormatter: Convert Double Newlines to Single`
    - `LineFormatter: Convert Single Newlines to Double`
+   - `LineFormatter: Convert Semicolons to Newlines`
 3. Run the command
 
 📝 The extension will apply the transformation to your selected text. If no text is selected, the entire document is transformed.
@@ -29,6 +31,7 @@
 |--------|-------------|
 | `LineFormatter: Convert Double Newlines to Single` | Replaces all occurrences of `\n\n` with `\n` |
 | `LineFormatter: Convert Single Newlines to Double` | Inserts an extra newline, avoiding duplication |
+| `LineFormatter: Convert Semicolons to Newlines` | Replaces all `;` with a newline |
 
 ---
 
@@ -50,12 +53,13 @@ MIT
 
 - `\n\n` を `\n` に置換
 - `\n` を `\n\n` に置換（連続改行は維持）
+- `;` を `\n` に置換
 - テキスト選択時は選択範囲だけ、選択なしならドキュメント全体が対象
 
 ### 🧭 使い方
 
-1. コマンドパレット（`Ctrl+Shift+P`）を開く  
-2. 「`LineFormatter: Convert Double Newlines to Single`」または「`LineFormatter: Convert Single Newlines to Double`」を実行  
+1. コマンドパレット（`Ctrl+Shift+P`）を開く
+2. 「`LineFormatter: Convert Double Newlines to Single`」または「`LineFormatter: Convert Single Newlines to Double`」、または「`LineFormatter: Convert Semicolons to Newlines`」を実行
 3. 結果を確認！
 
 ---

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
       {
         "command": "extension.convertSingleToDoubleNewline",
         "title": "LineFormatter: Convert Single Newlines to Double"
+      },
+      {
+        "command": "extension.convertSemicolonToNewline",
+        "title": "LineFormatter: Convert Semicolons to Newlines"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,19 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  context.subscriptions.push(convertDoubleToSingle, convertSingleToDouble);
+  const convertSemicolonToNewline = vscode.commands.registerCommand(
+    'extension.convertSemicolonToNewline',
+    () => {
+      // セミコロンを改行に置換
+      transformText((text) => text.replace(/;/g, '\n'));
+    }
+  );
+
+  context.subscriptions.push(
+    convertDoubleToSingle,
+    convertSingleToDouble,
+    convertSemicolonToNewline,
+  );
 }
 
 function transformText(transform: (text: string) => string) {


### PR DESCRIPTION
## Summary
- add command to convert semicolons to newlines
- document new feature in README
- list new command in package.json
- note addition in CHANGELOG

## Testing
- `npm run lint`
- `npm run compile`
- `npm test` *(fails: Missing X server or DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_68474c217be4832bbcf4c4205192cd4d